### PR TITLE
解决vgg和resnet在进行训练的时候准确率100%，表情识别时只能识别愤怒

### DIFF
--- a/data_process.py
+++ b/data_process.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pandas as pd
+from PIL import Image
+import os
+
+#直接通过fer2013.csv文件中的usage将图片分成训练集和验证集两个文件进行处理，放弃之前的数据处理操作，删掉三个数据处理文件
+#这里的fer2013.csv文件可以从kaggle上获取
+train_path = './dataset/train/'
+vaild_path = './dataset/vaild/'
+data_path = './fer2013.csv'
+
+def make_dir():
+    for i in range(0,7):
+        p1 = os.path.join(train_path,str(i))
+        p2 = os.path.join(vaild_path,str(i))
+        if not os.path.exists(p1):
+            os.makedirs(p1)
+        if not os.path.exists(p2):
+            os.makedirs(p2)
+
+def save_images():
+    df = pd.read_csv(data_path)
+    t_i = [1 for i in range(0,7)]
+    v_i = [1 for i in range(0,7)]
+    for index in range(len(df)):
+        emotion = df.loc[index][0]
+        image = df.loc[index][1]
+        usage = df.loc[index][2]
+        data_array = list(map(float, image.split()))
+        data_array = np.asarray(data_array)
+        image = data_array.reshape(48, 48)
+        im = Image.fromarray(image).convert('L')#8位黑白图片
+        if(usage=='Training'):
+            t_p = os.path.join(train_path,str(emotion),'{}.jpg'.format(t_i[emotion]))
+            im.save(t_p)
+            t_i[emotion] += 1
+        else:
+            v_p = os.path.join(vaild_path,str(emotion),'{}.jpg'.format(v_i[emotion]))
+            im.save(v_p)
+            v_i[emotion] += 1
+
+make_dir()
+save_images()

--- a/model_All_Compare.py
+++ b/model_All_Compare.py
@@ -22,9 +22,9 @@ LR = 0.01
 EPOCH = 60
 DEVICE = torch.device('cpu')
 
-
-path_train = '你选定模型的数据集'
-path_vaild = '你选定模型的验证集'
+#这里直接用分好的训练集和验证集
+path_train = '你选定模型的训练集'#train文件夹
+path_vaild = '你选定模型的验证集'#valid文件夹
 
 transforms_train = transforms.Compose([
     transforms.Grayscale(),#使用ImageFolder默认扩展为三通道，重新变回去就行


### PR DESCRIPTION
之前的数据处理操作创建了映射表，但是在vgg和resnet的训练过程中，代码部分并没有读取映射表中的类别信息，所以训练的时候准确率一直是100%，并且只能识别愤怒，而不是模型没有训练完成的问题，可以采用简易的数据处理操作，直接在处理过程将图片分类存放